### PR TITLE
Add `request-aws-iam-resources.yml` to ISSUE TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-aws-iam-resources.yml
+++ b/.github/ISSUE_TEMPLATE/request-aws-iam-resources.yml
@@ -1,0 +1,33 @@
+name: 'Request AWS IAM user or service account'
+description: 'Issue for requesting IAM accounts'
+labels: ['enhancement']
+
+body: 
+    - type: input
+      id: account-name
+      attributes:
+        label: Account Name
+        description: Provide github handle of new user or service account name (if requesting for a service)
+      validations: 
+        required: true
+    - type: input
+      id: project-name
+      attributes:
+        label: Project(s) Name
+        description: Specify the project you are working on
+      validations: 
+        required: true
+    - type: textarea
+      id: access-reason
+      attributes:
+        label: Reason for access
+        description: Mention the reason for requesting the access
+      validations:
+        required: true
+    - type: textarea
+      id: additional-info
+      attributes: 
+        label: Additional Information
+        description: Any other information you want to provide
+      validations:
+        required: false    


### PR DESCRIPTION
Fixes [#10](https://github.com/hackforla/devops-security/issues/10)

Provided a standardised issue-template for volunteers to request access for AWS IAM resources.

It will look like [this](https://github.com/freaky4wrld/ops/blob/adding-issue-template-10/.github/ISSUE_TEMPLATE/request-aws-iam-resources.yml)