### PR TITLE
updated README.md "Ops Community of Practice"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
+# proposed new ops wiki
+
 # Ops Community of Practice  
 
-Welcome to the Ops Community of Practice. We are happy you are here! Visit our [Wiki](https://github.com/hackforla/ops/wiki) for additional community info.
+Welcome to the Ops Community of Practice. We are happy you are here! 
+please Visit the below links for more info: 
+
+| [WIKI](https://github.com/hackforla/ops/wiki)                                   | for additional community info.                                      |
+|---------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| [CONTRIBUTING.md](https://github.com/hackforla/ops/blob/master/CONTRIBUTING.md) | guidelines for contributing to the ops repository hosted on GitHub. |
 
 <br>
 <br>
@@ -18,14 +25,14 @@ If you have not attended Hack for LA onboarding, plase read the [Guide for New V
 ### Step 1. Join Ops Community of Practice
 
 1. Join the [#ops](https://hackforla.slack.com/archives/CV7QGL66B) Slack channel and introduce yourself.
-2. Slack an [Ops Community of Practice lead]([https://www.hackforla.org/communities-of-practice](https://github.com/hackforla/ops/wiki/Community#ops-community-of-practice-cop-leads)) with your Gmail address.
-3. Accept your Google Drive invite to access the [shared folder]([https://drive.google.com/drive/u/0/folders/1xWllQli2wUSsRF9OaSQBBQ1vaY7kRkAT](https://drive.google.com/drive/folders/1XBuLSjOEKGfeVvWluIDyPYXTKHXhYHDM?usp=sharing)).
+2. Slack an [Ops Community of Practice lead](https://github.com/hackforla/ops/wiki/Community#ops-community-of-practice-cop-leads) with your Gmail address.
+3. Accept your Google Drive invite to access the google calendar and the [shared folder]([https://drive.google.com/drive/u/0/folders/1xWllQli2wUSsRF9OaSQBBQ1vaY7kRkAT](https://drive.google.com/drive/folders/1XBuLSjOEKGfeVvWluIDyPYXTKHXhYHDM?usp=sharing)).
 
 ### Step 2. Familiarize with Our Processes
 
 1. All Hack for LA teams use Kanban boards to encourage continuous improvements at all the level of the organization. Learn more about Kanban with our [Guide to How-To Use Our Github Kanban Board](https://docs.google.com/document/d/11Fe7mNdmPBP5bD_yLJ1C0_I1TmoK47AuHHrdhdDyWCs/edit#heading=h.nl3p4nf4eqb4) (working draft).
 2. Kanban is one of the popular frameworks used to implement agile development. Learn more about [Agile](https://www.atlassian.com/agile).
-3. Check out the currently [open Ops roles](https://github.com/orgs/hackforla/projects/67).
+3. Check out the currently [open Ops roles](https://github.com/hackforla/ops/projects/1).
 
 
 ### Step 3. Join the CoP Meeting - Come Meet devs from All Teams
@@ -36,4 +43,3 @@ If you have not attended Hack for LA onboarding, plase read the [Guide for New V
 The Ops Community of Practice is one of many.  [See all our Communities of Practices](https://github.com/hackforla/communities-of-practice/blob/main/README.md)
 
 See our [Code of Conduct](./CODEOFCONDUCT.md) and [License](./LICENSE) documents.
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# proposed new ops wiki
-
 # Ops Community of Practice  
 
 Welcome to the Ops Community of Practice. We are happy you are here! 


### PR DESCRIPTION
Fixes #[153](https://github.com/orgs/hackforla/projects/73/views/1?pane=issue&itemId=68061771&issue=hackforla%7Cops%7C135)

# What changes did you make?

### broken link
README.md
2. Slack an [Ops Community of Practice lead]([https://www.hackforla.org/communities-of-practice](https://github.com/hackforla/ops/wiki/Community#ops-community-of-practice-cop-leads)) with your Gmail address.
replaced with
2. Slack an [Ops Community of Practice lead](https://github.com/hackforla/ops/wiki/Community#ops-community-of-practice-cop-leads) with your Gmail address.
"Slack an [Ops Community of Practice lead]"

###  README.md added
2. Slack an [Ops Community of Practice lead]([https://www.hackforla.org/communities-of-practice](https://github.com/hackforla/ops/wiki/Community#ops-community-of-practice-cop-leads)) with your Gmail address.
seems pretty important so I'll leave it in the README.md that people will see first and
it can be removed from the WIKI

### How to participate
To get onto the calendar invites, send your email with your request to one of the [Ops CoP Leads](https://github.com/hackforla/ops/wiki/Community#ops-community-of-practice-cop-leads) on Slack.
get callendar
README.md added
"google calendar and the"
WIKI can be removed

### How to participate (question)
condition: To get onto the calendar invites, send your email with your request to one of the [Ops CoP Leads](https://github.com/hackforla/ops/wiki/Community#ops-community-of-practice-cop-leads) on Slack.
intermitant meetings
should we remove the following from the WIKI?
"The Ops Community of Practice (CoP) meets every Wednesday at 6:00pm PT except during planning weeks, which happen the first (full) week of each month."
resoning: when they see the callendar they will know

# Why did you make the changes (we will use this info to test)?
^ included above for each case
