### PR TITLE
Fixes #156 Make Ops to Devops changes in repo docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form.yml
@@ -27,6 +27,6 @@ body:
       label: "Resources/Instructions"
       description: "Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc."
       value: |
-        [Resources](https://github.com/hackforla/ops/wiki)
+        [Resources](https://github.com/hackforla/devops/wiki)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/offboard-ops-cop-lead.md
+++ b/.github/ISSUE_TEMPLATE/offboard-ops-cop-lead.md
@@ -12,12 +12,12 @@ We need to remove [NEW LEAD NAME] from the Ops CoP leads team.
 
 ### Offboard Checklist
 
-- [ ] Move to "previous leads" on the [community page](https://github.com/hackforla/ops/wiki/Community) on Wiki
+- [ ] Move to "previous leads" on the [community page](https://github.com/hackforla/devops/wiki/Community) on Wiki
 - [ ] Remove from [HfLA CoP page](https://www.hackforla.org/communities-of-practice) by filling out [this website issue](https://github.com/hackforla/website/issues/new?assignees=&labels=role%3A+product%2CP-Feature%3A+Communities+of+Practice%2Ctime+sensitive%2CComplexity%3A+Missing%2Csize%3A+missing&projects=&template=communities-of-practice-information-updates.yml&title=Communities+of+Practice+information+updates%3A+%5BINSERT+NAME+OF+Community+of+Practice%5D)
 - [ ] Demote to 'Contributor' on Ops Google drive
 - [ ] GitHub
-    - Change [write team](https://github.com/orgs/hackforla/teams/ops-write/members) role to 'member'
-    - Change [read team](https://github.com/orgs/hackforla/teams/ops/members) role to 'member'
+    - Change [write team](https://github.com/orgs/hackforla/teams/devops-write/members) role to 'member'
+    - Change [read team](https://github.com/orgs/hackforla/teams/devops/members) role to 'member'
 - [ ] Send name and email to Admin on Slack and ask to remove from 1 Password vaults:
     - Ops vault
     - Zoom vault

--- a/.github/ISSUE_TEMPLATE/onboard-ops-cop-lead.md
+++ b/.github/ISSUE_TEMPLATE/onboard-ops-cop-lead.md
@@ -12,28 +12,28 @@ We need to onboard [NEW LEAD NAME] onto the project.
 
 ### Onboard Checklist
 - [ ] Slack channel membership
-  - [ ] #ops
+  - [ ] #devops
 - [ ] Add to Google Calendar invites
   - [ ] Ops meeting
   - [ ] Monthly CoP leads meeting
 - [ ] Figma
   - [ ] invite
   - [ ] acceptance
-- [ ] Add to [community page](https://github.com/hackforla/ops/wiki/Community) on Wiki
+- [ ] Add to [community page](https://github.com/hackforla/devops/wiki/Community) on Wiki
 - [ ] Add to [HfLA CoP page](https://www.hackforla.org/communities-of-practice) by filling out [this website issue](https://github.com/hackforla/website/issues/new?assignees=&labels=role%3A+product%2CP-Feature%3A+Communities+of+Practice%2Ctime+sensitive%2CComplexity%3A+Missing%2Csize%3A+missing&projects=&template=communities-of-practice-information-updates.yml&title=Communities+of+Practice+information+updates%3A+%5BINSERT+NAME+OF+Community+of+Practice%5D)
 - [ ] Google Drive
    - [ ] Add to Ops drive as Manager
 - [ ] GitHub
-     - [ ] Add to team [write team](https://github.com/orgs/hackforla/teams/ops-write/members)
+     - [ ] Add to team [write team](https://github.com/orgs/hackforla/teams/devops-write/members)
         - [ ] Change membership to maintainer
-     - [ ] Add to [read team](https://github.com/orgs/hackforla/teams/ops/members)
+     - [ ] Add to [read team](https://github.com/orgs/hackforla/teams/devops/members)
         - [ ] Change membership to maintainer
      - [ ] Check their github handle by assigning them to this issue, to see if they have added their name, so that you don't have to memorize their handle
 - [ ] 1password 
      - [ ] Send name and email to Admin on Slack and ask to grant access to:
        - Ops vault
        - Zoom vault
-   - [ ] make sure they can log onto ops@hackforla.org
+   - [ ] make sure they can log onto devops@hackforla.org
 - [ ] Train how to 
    - [ ] login to team email account
    - [ ] use zoom spreadsheet, vault, and accounts

--- a/.github/ISSUE_TEMPLATE/recruit-new-lead.md
+++ b/.github/ISSUE_TEMPLATE/recruit-new-lead.md
@@ -12,8 +12,8 @@ assignees: ''
 We need a lead to help us out with [description of work needed].
 
 ### Action Items
-- [ ] Post card on [Open Roles board](https://github.com/hackforla/ops/projects/1)
-- [ ] Post in [Community Leads Open Roles wiki](https://github.com/hackforla/ops/wiki/Community-Leads-Roles)
+- [ ] Post card on [Open Roles board](https://github.com/hackforla/devops/projects/1)
+- [ ] Post in [Community Leads Open Roles wiki](https://github.com/hackforla/devops/wiki/Community-Leads-Roles)
 - [ ] Notify community in [#Ops Slack](https://hackforla.slack.com/archives/CV7QGL66B)
 - [ ] Notify community in CoP meeting
 - [ ] Host an info session with interested parties

--- a/.github/ISSUE_TEMPLATE/recruit-new-lead.md
+++ b/.github/ISSUE_TEMPLATE/recruit-new-lead.md
@@ -1,7 +1,7 @@
 ---
 name: Recruit new lead
-about: Use this checklist when recruiting a new Ops CoP Lead
-title: Recruit new Ops CoP lead
+about: Use this checklist when recruiting a new Devops CoP Lead
+title: Recruit new Devops CoP lead
 labels: 'role: CoP lead'
 assignees: ''
 
@@ -14,7 +14,7 @@ We need a lead to help us out with [description of work needed].
 ### Action Items
 - [ ] Post card on [Open Roles board](https://github.com/hackforla/devops/projects/1)
 - [ ] Post in [Community Leads Open Roles wiki](https://github.com/hackforla/devops/wiki/Community-Leads-Roles)
-- [ ] Notify community in [#Ops Slack](https://hackforla.slack.com/archives/CV7QGL66B)
+- [ ] Notify community in [#Devops Slack](https://hackforla.slack.com/archives/CV7QGL66B)
 - [ ] Notify community in CoP meeting
 - [ ] Host an info session with interested parties
    - [ ] able to commit to at least 6 months

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# **How to Contribute to Ops**
+# **How to Contribute to DevOps**
 
 Thank you for taking the time to contribute!
 
@@ -13,7 +13,7 @@ The following guidelines are for contributing to the ops repository hosted on Gi
 
 ## **Table of Contents**
 
-- [**How to Contribute to Ops**](#how-to-contribute-to-ops)
+- [**How to Contribute to DevOps**](#how-to-contribute-to-ops)
   - [**Table of Contents**](#table-of-contents)
   - [**Setting up the local development environment**](#setting-up-the-local-development-environment)
   - [**Fork the repository**](#fork-the-repository)
@@ -176,7 +176,7 @@ Choose a branch name that:
 - relates to the issue (No spaces!)
 - includes the issue number
 
-For example, if you create a new issue branch for [Add a CONTRIBUTING.md to the Ops repo #120](https://github.com/hackforla/ops/issues/120):
+For example, if you create a new issue branch for [Add a CONTRIBUTING.md to the DevOps repo #120](https://github.com/hackforla/ops/issues/120):
 
 ```bash
 git checkout -b add-contributing-md-120

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ The following guidelines are for contributing to the ops repository hosted on Gi
 
 ## **Table of Contents**
 
-- [**How to Contribute to DevOps**](#how-to-contribute-to-ops)
+- [**How to Contribute to DevOps**](#how-to-contribute-to-devops)
   - [**Table of Contents**](#table-of-contents)
   - [**Setting up the local development environment**](#setting-up-the-local-development-environment)
   - [**Fork the repository**](#fork-the-repository)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Ops Community of Practice  
+# DevOps Community of Practice  
 
-Welcome to the Ops Community of Practice. We are happy you are here! 
+Welcome to the DevOps Community of Practice. We are happy you are here! 
 please Visit the below links for more info: 
 
 | [WIKI](https://github.com/hackforla/ops/wiki)                                   | for additional community info.                                      |
@@ -20,24 +20,24 @@ Wednesday nights 6:00PM Pacific Time
 If you have not attended Hack for LA onboarding, plase read the [Guide for New Volunteers](https://www.hackforla.org/getting-started), and register for an upcoming onboarding session.  
 
 
-### Step 1. Join Ops Community of Practice
+### Step 1. Join DevOps Community of Practice
 
 1. Join the [#ops](https://hackforla.slack.com/archives/CV7QGL66B) Slack channel and introduce yourself.
-2. Slack an [Ops Community of Practice lead](https://github.com/hackforla/ops/wiki/Community#ops-community-of-practice-cop-leads) with your Gmail address.
+2. Slack an [DevOps Community of Practice lead](https://github.com/hackforla/ops/wiki/Community#ops-community-of-practice-cop-leads) with your Gmail address.
 3. Accept your Google Drive invite to access the google calendar and the [shared folder]([https://drive.google.com/drive/u/0/folders/1xWllQli2wUSsRF9OaSQBBQ1vaY7kRkAT](https://drive.google.com/drive/folders/1XBuLSjOEKGfeVvWluIDyPYXTKHXhYHDM?usp=sharing)).
 
 ### Step 2. Familiarize with Our Processes
 
 1. All Hack for LA teams use Kanban boards to encourage continuous improvements at all the level of the organization
 2. We use Kanban Project Boards to manage our project [CoP: DevOps: Project Board](https://github.com/orgs/hackforla/projects/73)
-3. Check out the currently [open Ops roles](https://github.com/orgs/hackforla/projects/67/views/7).
+3. Check out the currently [open DevOps roles](https://github.com/orgs/hackforla/projects/67/views/7).
 
 
 ### Step 3. Join the CoP Meeting - Come Meet devs from All Teams
 
-* Join our Ops Community of Practice meeting Wednesdays at 6 PM PST
+* Join our DevOps Community of Practice meeting Wednesdays at 6 PM PST
 * Take the [Remote Onboarding Survey](https://docs.google.com/forms/d/e/1FAIpQLScXnJSyCXgO_RCAuCyOkG4sqGILpAepTlJ0HOaK4H_ccEVmNw/viewform) to provide feedback about your experience joining Hack for LA.
 
-The Ops Community of Practice is one of many.  [See all our Communities of Practices](https://github.com/hackforla/communities-of-practice/blob/main/README.md)
+The DevOps Community of Practice is one of many.  [See all our Communities of Practices](https://github.com/hackforla/communities-of-practice/blob/main/README.md)
 
 See our [Code of Conduct](https://www.hackforla.org/code-of-conduct/) and [License](./LICENSE) documents.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you have not attended Hack for LA onboarding, plase read the [Guide for New V
 ### Step 1. Join DevOps Community of Practice
 
 1. Join the [#ops](https://hackforla.slack.com/archives/CV7QGL66B) Slack channel and introduce yourself.
-2. Slack an [DevOps Community of Practice lead](https://github.com/hackforla/ops/wiki/Community#ops-community-of-practice-cop-leads) with your Gmail address.
+2. Slack a [DevOps Community of Practice lead](https://github.com/hackforla/devops/wiki/Community#ops-community-of-practice-cop-leads) with your Gmail address.
 3. Accept your Google Drive invite to access the google calendar and the [shared folder]([https://drive.google.com/drive/u/0/folders/1xWllQli2wUSsRF9OaSQBBQ1vaY7kRkAT](https://drive.google.com/drive/folders/1XBuLSjOEKGfeVvWluIDyPYXTKHXhYHDM?usp=sharing)).
 
 ### Step 2. Familiarize with Our Processes


### PR DESCRIPTION
Fixes #156 by replacing Ops terms to Devops

### What changes did you make?
**README.md**: replace all instances of 'Ops' to 'DevOps'
**CONTRIBUTING.md**: replace all instances of 'Ops' to 'DevOps'
**.github/ISSUE_TEMPLATE/offboard-ops-cop-lead.md**: change instances of 'ops' to 'devops'
**.github/ISSUE_TEMPLATE/onboard-ops-cop-lead.md**: change instances of 'ops' to 'devops'
**.github/ISSUE_TEMPLATE/recruit-new-lead.md**: change instances of 'ops' to 'devops'
**.github/ISSUE_TEMPLATE/blank-issue-form.yaml**: in resources, change 'ops' repo link to 'devops'

### Why did you make the changes (we will use this info to test)?
  - It was detailed in the Issue.
