### PR TITLE
Add labels and project board to blank issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-form-d.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form-d.yml
@@ -1,6 +1,7 @@
 name: "Blank Issue Form (w/ Dependency)"
 description: "Form version of HackforLA blank issue template with dependency"
-labels: ["Dependency"]
+labels: ['size: missing', 'role: missing', 'feature: missing', 'complexity: missing', 'milestone: missing', 'dependency', 'draft']
+projects: ['hackforla/73'] # CoP: DevOps: Project Board
 
 body:
   - type: textarea
@@ -37,6 +38,6 @@ body:
       label: "Resources/Instructions"
       description: "Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc."
       value: |
-        [Resources](https://github.com/hackforla/ops/wiki)
+        [Resources](https://github.com/hackforla/devops/wiki)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/blank-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form.yml
@@ -1,5 +1,7 @@
 name: "Blank Issue Form (w/o Dependency)"
 description: "Form version of HackforLA blank issue template without dependency"
+labels: ['size: missing', 'role: missing', 'feature: missing', 'complexity: missing', 'milestone: missing', 'draft']
+projects: ['hackforla/73'] # CoP: DevOps: Project Board
 
 body:
   - type: textarea


### PR DESCRIPTION
### What changes did you make?
  - `blank-issue-form.yml` had no `labels:` and no `projects:` at all. Added `size/role/feature/complexity/milestone: missing` plus `draft`, and `projects: ['hackforla/73']`.
  - `blank-issue-form-d.yml` applied only `Dependency`. Replaced with the same set plus `dependency`, and added the same `projects:`.
  - Fixed the label casing: the repo's label is lowercase `dependency`.
  - Fixed the dependency form's Resources default, which still linked to `github.com/hackforla/ops/wiki` — the pre-rename repo name. Its sibling form already said `devops`.

### Why did you make the changes (we will use this info to test)?
  - No template in this repo applied the missing-label convention, even though all five labels exist here. Issues arrived with no labels — #166 and #163 both have zero.
  - No template set `projects:`, so issues reached the CoP: DevOps: Project Board only when someone remembered to add them by hand. #166 is on no board at all.
  - All seven labels were verified to exist in this repo with matching casing before being added — checked against `gh label list`, 0 mismatches.
  - To test: click New Issue, pick either form, and confirm the labels and project shown at the bottom before submitting.

Deliberately left alone, tracked separately:
  - The Overview `placeholder:` text is unchanged — it is the best Overview guidance in any of the three repos and should be the basis for converging them, not replaced.
  - `blank-issue.md` is a third, label-less blank variant that duplicates the no-dependency form and should be deleted.
  - Both forms set `value:` on Action Items and Resources, so those fields are never empty and their `required: true` can never fail — submitting unedited ships an issue whose action items read "Item 1 / Item 2".
  - `recruit-new-lead.md` links to `hackforla/devops/projects/1`, a retired classic project board that now 404s, and has an empty `[Onboard]()` link.