### PR TITLE
Stop applying draft to every new issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-form-d.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form-d.yml
@@ -1,6 +1,6 @@
 name: "Blank Issue Form (w/ Dependency)"
 description: "Form version of HackforLA blank issue template with dependency"
-labels: ['size: missing', 'role: missing', 'feature: missing', 'complexity: missing', 'milestone: missing', 'dependency', 'draft']
+labels: ['size: missing', 'role: missing', 'feature: missing', 'complexity: missing', 'milestone: missing', 'dependency']
 projects: ['hackforla/73'] # CoP: DevOps: Project Board
 
 body:

--- a/.github/ISSUE_TEMPLATE/blank-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form.yml
@@ -1,6 +1,6 @@
 name: "Blank Issue Form (w/o Dependency)"
 description: "Form version of HackforLA blank issue template without dependency"
-labels: ['size: missing', 'role: missing', 'feature: missing', 'complexity: missing', 'milestone: missing', 'draft']
+labels: ['size: missing', 'role: missing', 'feature: missing', 'complexity: missing', 'milestone: missing']
 projects: ['hackforla/73'] # CoP: DevOps: Project Board
 
 body:


### PR DESCRIPTION
### What changes did you make?
  - Removed `draft` from the default `labels:` on both blank issue forms. No other label changed.

### Why did you make the changes (we will use this info to test)?
  - Every field on these forms is `required: true`, so the form cannot actually produce the stub that `draft` implies — the label was applied to complete issues.
  - Nothing in the CoP's weekly process removes it. The Weekly Label check (hackforla/devops#23) has no de-draft step, and the agenda template (hackforla/devops#162) has a prework item described as "no ready for no draft assignee" whose query contains no `draft` term at all. So the label accumulated on every issue with nothing taking it off.
  - The `draft` label itself is untouched and can still be applied by hand when someone genuinely wants to mark an issue as not ready.
  - To test: click New Issue, pick either blank form, and confirm the labels listed at the bottom no longer include `draft`.

Applied identically across all three DevOps repos: hackforla/devops-security, hackforla/incubator, hackforla/devops.